### PR TITLE
ignore storybook stories when validating extraneous dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,8 @@
       "error",
       {
         "devDependencies": [
-          "**/*.spec.[tj]s"
+          "**/*.spec.[tj]s",,
+          "**/*.stories.[jt]s[x]"
         ]
       }
     ],


### PR DESCRIPTION
ignore `import/no-extraneous-dependencies` rule in storybook files